### PR TITLE
fix: center single focus block when there's only one

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -39,7 +39,7 @@ title: Home
     <section class="my-8" id="current-focus">
         <h2 class="text-2xl mb-4">Current Professional Focus</h2>
         {% from "macros/experience-item.njk" import experienceItem %}
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-16">
+        <div class="flex justify-center">
             {{ experienceItem(
                 "/img/vibecto.png",
                 "Vibecto.ai",


### PR DESCRIPTION
Changes the Current Professional Focus section from a 2-column grid layout to a centered flex layout. This centers the single focus item instead of left-aligning it when there's only one focus block.

Resolves #15

Generated with [Claude Code](https://claude.ai/code)